### PR TITLE
More numba optimizations

### DIFF
--- a/nbody/numba/nbody/barnes_hut_array/energy.py
+++ b/nbody/numba/nbody/barnes_hut_array/energy.py
@@ -1,28 +1,37 @@
+from __future__ import print_function
+
 import numpy as np
 from .quadTree import quadArray
 import time
 
+
 def compute_energy(mass, particles, energy):
+    print('compute energy:')
+    t_tot = time.time()
+
     bmin = np.min(particles[: ,:2], axis=0)
     bmax = np.max(particles[: ,:2], axis=0)
     root = quadArray(bmin, bmax, particles.shape[0])
 
-    print('build tree')
+    print('\tbuild tree:    ', end='', flush=True)
     t1 = time.time()
     root.buildTree(particles)
     t2 = time.time()
-    print(t2-t1)
+    print('{:9.4f}ms'.format(1000*(t2-t1)))
 
-    print('compute mass')
+    print('\tcompute mass:  ', end='', flush=True)
     t1 = time.time()
     root.computeMassDistribution(particles, mass)
     t2 = time.time()
-    print(t2-t1)
+    print('{:9.4f}ms'.format(1000*(t2-t1)))
 
+    print('\tcompute force: ', end='', flush=True)
     t1 = time.time()    
     for i in range(particles.shape[0]):
         acc = root.computeForce(particles[i])
         energy[i, 2:] = acc
     energy[:, :2] = particles[:, 2:]
     t2 = time.time()
-    print(t2-t1)
+    print('{:9.4f}ms'.format(1000*(t2-t1)))
+
+    print('\ttotal:       {:11.4f}ms'.format(1000*(time.time()-t_tot)))

--- a/nbody/numba/nbody/barnes_hut_array/energy.py
+++ b/nbody/numba/nbody/barnes_hut_array/energy.py
@@ -4,6 +4,15 @@ import numpy as np
 from .quadTree import quadArray
 import time
 
+from . import numba_functions
+import numba
+
+@numba.njit
+def compute_force( nbodies, child, center_of_mass, mass, cell_radius, particles, energy):
+    for i in range(particles.shape[0]):
+        acc = numba_functions.computeForce( nbodies, child, center_of_mass, mass, cell_radius, particles[i] )
+        energy[i, 2] = acc[0]
+        energy[i, 3] = acc[1]
 
 def compute_energy(mass, particles, energy):
     print('compute energy:')
@@ -27,9 +36,7 @@ def compute_energy(mass, particles, energy):
 
     print('\tcompute force: ', end='', flush=True)
     t1 = time.time()    
-    for i in range(particles.shape[0]):
-        acc = root.computeForce(particles[i])
-        energy[i, 2:] = acc
+    compute_force( root.nbodies, root.child, root.center_of_mass, root.mass, root.cell_radius, particles, energy )
     energy[:, :2] = particles[:, 2:]
     t2 = time.time()
     print('{:9.4f}ms'.format(1000*(t2-t1)))

--- a/nbody/numba/nbody/barnes_hut_array/energy.py
+++ b/nbody/numba/nbody/barnes_hut_array/energy.py
@@ -7,9 +7,9 @@ import time
 from . import numba_functions
 import numba
 
-@numba.njit
+@numba.njit(parallel=True)
 def compute_force( nbodies, child, center_of_mass, mass, cell_radius, particles, energy):
-    for i in range(particles.shape[0]):
+    for i in numba.prange(particles.shape[0]):
         acc = numba_functions.computeForce( nbodies, child, center_of_mass, mass, cell_radius, particles[i] )
         energy[i, 2] = acc[0]
         energy[i, 3] = acc[1]

--- a/nbody/numba/nbody/barnes_hut_array/numba_functions.py
+++ b/nbody/numba/nbody/barnes_hut_array/numba_functions.py
@@ -139,15 +139,17 @@ def computeForce(nbodies, child_array, center_of_mass, mass, cell_radius, p):
             localPos[depth] += 1
             if child >= 0:
                 if child < nbodies:
-                    F = force(pos, center_of_mass[child], mass[child])
-                    acc += F
+                    Fx, Fy = force(pos, center_of_mass[child], mass[child])
+                    acc[0] += Fx
+                    acc[1] += Fy
                 else:
                     dx = center_of_mass[child, 0] - pos[0]
                     dy = center_of_mass[child, 1] - pos[1]
                     dist = np.sqrt(dx**2 + dy**2)
                     if dist != 0 and cell_radius[child - nbodies][0]/dist <.5:
-                        F = force(pos, center_of_mass[child], mass[child])
-                        acc += F
+                        Fx, Fy = force(pos, center_of_mass[child], mass[child])
+                        acc[0] += Fx
+                        acc[1] += Fy
                     else:
                         depth += 1
                         localNode[depth] = nbodies + 4*(child-nbodies)

--- a/nbody/numba/nbody/barnes_hut_array/numba_functions.py
+++ b/nbody/numba/nbody/barnes_hut_array/numba_functions.py
@@ -153,4 +153,21 @@ def computeForce(nbodies, child_array, center_of_mass, mass, cell_radius, p):
                         localNode[depth] = nbodies + 4*(child-nbodies)
                         localPos[depth] = 0
         depth -= 1
-    return acc    
+    return acc
+
+@numba.njit
+def computeMassDistribution(nbodies, ncell, child, mass, center_of_mass ):
+    for i in range(ncell, -1, -1):
+        this_mass = 0
+        this_center_of_mass = [0, 0]
+        for j in range( nbodies + 4*i, nbodies + 4*i + 4 ):
+            element_id = child[j]
+            if element_id >= 0:
+                this_mass += mass[ element_id ]
+                this_center_of_mass[0] += center_of_mass[element_id][0] * mass[element_id]
+                this_center_of_mass[1] += center_of_mass[element_id][1] * mass[element_id]
+
+        center_of_mass[nbodies + i][0] = this_center_of_mass[0] / this_mass
+        center_of_mass[nbodies + i][1] = this_center_of_mass[1] / this_mass
+        mass[nbodies + i] = this_mass
+

--- a/nbody/numba/nbody/barnes_hut_array/quadTree.py
+++ b/nbody/numba/nbody/barnes_hut_array/quadTree.py
@@ -24,14 +24,10 @@ class quadArray:
         self.mass[:self.nbodies] = mass
         self.center_of_mass = np.zeros((self.nbodies + self.ncell + 1, 2))
         self.center_of_mass[:self.nbodies] = particles[:, :2]
-        for i in range(self.ncell, -1, -1):
-            elements = self.child[self.nbodies + 4*i:self.nbodies + 4*i + 4]
-            #print('elements', i, elements, self.center_of_mass[elements[elements>=0]]*self.mass[elements[elements>=0]])
-            self.mass[self.nbodies + i] = np.sum(self.mass[elements[elements>=0]])
-            self.center_of_mass[self.nbodies + i] = np.sum(self.center_of_mass[elements[elements>=0]]*self.mass[elements[elements>=0], np.newaxis], axis=0)
-            self.center_of_mass[self.nbodies + i] /= self.mass[self.nbodies + i]
-        # print('mass', self.mass)
-        # print('center_of_mass', self.center_of_mass)
+
+        numba_functions.computeMassDistribution( self.nbodies, self.ncell,
+                self.child, self.mass, self.center_of_mass )
+
 
     def computeForce(self, p):
         return numba_functions.computeForce(self.nbodies, self.child, self.center_of_mass, self.mass, self.cell_radius, p)
@@ -47,3 +43,4 @@ class quadArray:
             s += 2*indent + 'cells: {c}\n'.format(c=cellElements[cellElements>=self.nbodies]-self.nbodies)
             
         return s
+

--- a/nbody/numba/nbody/forces.py
+++ b/nbody/numba/nbody/forces.py
@@ -13,4 +13,4 @@ def force(p1, p2, m2):
     if dist > 0:
         F = (gamma_si * m2) / (dist*dist*dist)
 
-    return np.array([F * dx, F * dy])
+    return F * dx, F * dy


### PR DESCRIPTION
Some more numba optimizations.

As an example, times drop from
```
compute energy:
	build tree:       1.2801ms
	compute mass:    40.8738ms
	compute force:   53.6926ms
	total:           96.1435ms
```
to
```
compute energy:
	build tree:       1.3587ms
	compute mass:     0.3927ms
	compute force:   11.3230ms
	total:           13.2930ms
```
and, using 2 threads for the compute force loop:
```
compute energy:
	build tree:       1.3180ms
	compute mass:     0.3901ms
	compute force:    5.5034ms
	total:            7.4086ms
```